### PR TITLE
Add option for disabling SSL Authentication

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -210,6 +210,10 @@ msgctxt "#32048"
 msgid "No downloaded videos for offline mode!"
 msgstr ""
 
+msgctxt "#32049"
+msgid "Disable SSL Authentication"
+msgstr ""
+
 msgctxt "#32075"
 msgid "Enable 4K (default 1080p)"
 msgstr ""

--- a/resources/language/resource.language.es_es/strings.po
+++ b/resources/language/resource.language.es_es/strings.po
@@ -210,6 +210,10 @@ msgctxt "#32048"
 msgid "No downloaded videos for offline mode!"
 msgstr ""
 
+msgctxt "#32049"
+msgid "Disable SSL Authentication"
+msgstr "Deshabilitar la autenticación SSL"
+
 msgctxt "#32075"
 msgid "Enable 4K (default 1080p)"
 msgstr "Habilitar 4K"
@@ -441,4 +445,3 @@ msgstr "Habilitar West Africa to the Alps"
 msgctxt "#32132"
 msgid "Enable Yosemite"
 msgstr "Habilitar Yosemite"
-

--- a/resources/language/resource.language.pt_pt/strings.po
+++ b/resources/language/resource.language.pt_pt/strings.po
@@ -210,6 +210,10 @@ msgctxt "#32048"
 msgid "Offline mode but no downloaded videos!"
 msgstr "Modo offline ativo mas não existem videos no disco"
 
+msgctxt "#32049"
+msgid "Disable SSL Authentication"
+msgstr "Desabilitar autenticação SSL"
+
 msgctxt "#32075"
 msgid "Enable 4K (default 1080p)"
 msgstr "Ativar 4K"

--- a/resources/lib/commonatv.py
+++ b/resources/lib/commonatv.py
@@ -9,6 +9,9 @@
 import xbmcaddon
 import xbmcgui
 
+import ssl
+from urllib.request import build_opener, install_opener, HTTPSHandler
+
 addon = xbmcaddon.Addon()
 addon_path = addon.getAddonInfo("path")
 addon_icon = addon.getAddonInfo("icon")
@@ -55,3 +58,14 @@ def compute_block_key_list(enable_4k, enable_hdr, enable_hevc):
     # Always check H264 as the default option
     block_key_list.append("url-1080-H264")
     return block_key_list
+
+if addon.getSettingBool("disable-ssl"):
+    # Create an opener with the custom SSL context
+    context = ssl.create_default_context()
+    context.check_hostname = False
+    context.verify_mode = ssl.CERT_NONE
+    https_handler = HTTPSHandler(context=context)
+    opener = build_opener(https_handler)
+
+    # Install the opener
+    install_opener(opener)

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -418,6 +418,11 @@
 					<default>true</default>
 					<control type="toggle"/>
 				</setting>
+				<setting id="disable-ssl" type="boolean" label="32049" help="">
+					<level>0</level>
+					<default>false</default>
+					<control type="toggle"/>
+				</setting>
 				<setting id="run-downloader" type="action" label="32011" help="">
 					<level>0</level>
 					<data>RunAddon(screensaver.atv4,offline)</data>


### PR DESCRIPTION
Due to network restrictions in China, access to some outbound websites are unstable. In terms of Apple sites, SSL auth is especially susceptible to MITM attack, which presents a fake certificate and try to lure the end user into the trap. Since downloading screensavers are not concerned with personal info, disabling SSL auth can save lots of futile attempts to load the screensavers.
Anyway, it may be a nitche case, but it may help others enduring similar situations.