### PR TITLE
Enable/disable videos based on time of day

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -441,3 +441,19 @@ msgstr ""
 msgctxt "#32132"
 msgid "Enable Yosemite"
 msgstr ""
+
+msgctxt "#34001"
+msgid "On"
+msgstr ""
+
+msgctxt "#34002"
+msgid "Day Only"
+msgstr ""
+
+msgctxt "#34003"
+msgid "Night Only"
+msgstr ""
+
+msgctxt "#34004"
+msgid "Off"
+msgstr ""

--- a/resources/language/resource.language.es_es/strings.po
+++ b/resources/language/resource.language.es_es/strings.po
@@ -442,3 +442,18 @@ msgctxt "#32132"
 msgid "Enable Yosemite"
 msgstr "Habilitar Yosemite"
 
+msgctxt "#34001"
+msgid "On"
+msgstr "Encendido"
+
+msgctxt "#34002"
+msgid "Day Only"
+msgstr "Solamente Dia"
+
+msgctxt "#34003"
+msgid "Night Only"
+msgstr "Solamente Noche"
+
+msgctxt "#34004"
+msgid "Off"
+msgstr "Apagado"

--- a/resources/language/resource.language.pt_pt/strings.po
+++ b/resources/language/resource.language.pt_pt/strings.po
@@ -441,3 +441,20 @@ msgstr "Ativar West Africa to the Alps"
 msgctxt "#32132"
 msgid "Enable Yosemite"
 msgstr "Ativar Yosemite"
+
+msgctxt "#34001"
+msgid "On"
+msgstr "Ligadas"
+
+msgctxt "#34002"
+msgid "Day Only"
+msgstr "Apenas Dia"
+
+msgctxt "#34003"
+msgid "Night Only"
+msgstr "Apenas a Noite"
+
+msgctxt "#34004"
+msgid "Off"
+msgstr "Desligado"
+

--- a/resources/lib/playlist.py
+++ b/resources/lib/playlist.py
@@ -11,6 +11,7 @@ import os
 import tarfile
 from random import shuffle
 from urllib import request
+import datetime as dt
 
 import xbmc
 import xbmcvfs
@@ -84,7 +85,11 @@ class AtvPlaylist:
                     current_location_state = addon.getSettingInt("enable-" + location.lower().replace(" ", ""))
                     xbmc.log(f"Current location state is {current_location_state}", level=xbmc.LOGDEBUG)
                     # returns True if system time between start/end time, else False
-                    day = xbmc.getInfoLabel("System.Time(06:00,18:00)")
+                    systime = xbmc.getInfoLabel("System.Time(hh:mm xx)")
+                    systime = dt.datetime.strptime(systime, "%I:%M %p")
+                    start_time = dt.datetime.strptime("6:00 AM", "%I:%M %p")
+                    end_time = dt.datetime.strptime("6:00 PM", "%I:%M %p")
+                    day = True if (start_time <= systime < end_time) else False
                     xbmc.log(f"Currently {'day' if day else 'night'}time", level=xbmc.LOGDEBUG)
                     # always on
                     if current_location_state == 0:

--- a/resources/lib/playlist.py
+++ b/resources/lib/playlist.py
@@ -26,7 +26,6 @@ apple_local_tar_path = os.path.join(addon_path, "resources.tar")
 # Local save location of the entries.json file containing video URLs
 local_entries_json_path = os.path.join(addon_path, "resources", "entries.json")
 
-
 # Fetch the TAR file containing the latest entries.json and overwrite the local copy
 def get_latest_entries_from_apple():
     xbmc.log("Downloading the Apple Aerials resources.tar to disk", level=xbmc.LOGDEBUG)
@@ -81,8 +80,25 @@ class AtvPlaylist:
                 # Retrieve the location name
                 location = block["accessibilityLabel"]
                 try:
-                    # Get the corresponding setting Bool by adding "enable-" + lowercase + no whitespace
-                    current_location_enabled = addon.getSettingBool("enable-" + location.lower().replace(" ", ""))
+                    # determine if current video is enabled (on, day, night, off)
+                    current_location_state = addon.getSettingInt("enable-" + location.lower().replace(" ", ""))
+                    xbmc.log(f"Current location state is {current_location_state}", level=xbmc.LOGDEBUG)
+                    # returns True if system time between start/end time, else False
+                    day = xbmc.getInfoLabel("System.Time(06:00,18:00)")
+                    xbmc.log(f"Currently {'day' if day else 'night'}time", level=xbmc.LOGDEBUG)
+                    # always on
+                    if current_location_state == 0:
+                        current_location_enabled = True
+                    # enabled for day and currently day
+                    elif current_location_state == 1 and day:
+                        current_location_enabled = True
+                    # enabled for night and currently night
+                    elif current_location_state == 2 and not day:
+                        current_location_enabled = True
+                    # disabled
+                    else:
+                        current_location_enabled = False
+
                 except TypeError:
                     xbmc.log("Location {} did not have a matching enable/disable setting".format(location),
                              level=xbmc.LOGDEBUG)

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,432 +1,847 @@
-<?xml version="1.0" ?>
 <settings version="1">
-	<section id="screensaver.atv4">
-		<category id="aerial screensavers" label="32000" help="">
-			<group id="1" label="32032">
-				<setting id="show-notifications" type="boolean" label="32018" help="">
-					<level>0</level>
-					<default>false</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="show-previewwindow" type="boolean" label="32042" help="">
-					<level>0</level>
-					<default>false</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-4k" type="boolean" label="32075" help="">
-					<level>0</level>
-					<default>false</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-hdr" type="boolean" label="32076" help="">
-					<level>0</level>
-					<default>false</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-hevc" type="boolean" label="32077" help="">
-					<level>0</level>
-					<default>false</default>
-					<control type="toggle"/>
-				</setting>
-			</group>
-			<group id="2" label="32026">
-				<setting id="check-dpms" type="integer" label="32027" help="">
-					<level>0</level>
-					<default>0</default>
-					<constraints>
-						<options>
-							<option label="32035">0</option>
-							<option label="32036">1</option>
-							<option label="32037">2</option>
-						</options>
-					</constraints>
-					<control type="spinner" format="string"/>
-				</setting>
-				<setting id="dpms-action" type="integer" label="32039" help="">
-					<level>0</level>
-					<default>0</default>
-					<constraints>
-						<options>
-							<option label="32040">0</option>
-							<option label="32041">1</option>
-						</options>
-					</constraints>
-					<dependencies>
-						<dependency type="visible">
-							<or>
-								<condition operator="is" setting="check-dpms">1</condition>
-								<condition operator="is" setting="check-dpms">2</condition>
-							</or>
-						</dependency>
-					</dependencies>
-					<control type="spinner" format="string"/>
-				</setting>
-				<setting id="manual-dpms" type="integer" label="32038" help="">
-					<level>0</level>
-					<default>5</default>
-					<constraints>
-						<minimum>1</minimum>
-						<step>5</step>
-						<maximum>120</maximum>
-					</constraints>
-					<dependencies>
-						<dependency type="visible">
-							<condition operator="is" setting="check-dpms">2</condition>
-						</dependency>
-					</dependencies>
-					<control type="slider" format="integer">
-						<popup>false</popup>
-					</control>
-				</setting>
-				<setting id="toggle-displayoff" type="boolean" label="32028" help="">
-					<level>0</level>
-					<default>false</default>
-					<dependencies>
-						<dependency type="visible">
-							<or>
-								<condition operator="is" setting="check-dpms">1</condition>
-								<condition operator="is" setting="check-dpms">2</condition>
-							</or>
-						</dependency>
-					</dependencies>
-					<control type="toggle"/>
-				</setting>
-				<setting id="toggle-cecoff" type="boolean" label="32029" help="">
-					<level>0</level>
-					<default>false</default>
-					<dependencies>
-						<dependency type="visible">
-							<or>
-								<condition operator="is" setting="check-dpms">1</condition>
-								<condition operator="is" setting="check-dpms">2</condition>
-							</or>
-						</dependency>
-					</dependencies>
-					<control type="toggle"/>
-				</setting>
-			</group>
-			<group id="3" label="32033"/>
-			<group id="4" label="32034">
-				<setting id="is_locked" type="boolean" help="">
-					<level>0</level>
-					<default>false</default>
-					<dependencies>
-						<dependency type="visible">
-							<condition on="property" name="InfoBool">false</condition>
-						</dependency>
-					</dependencies>
-					<control type="toggle"/>
-				</setting>
-			</group>
-		</category>
-		<category id="videos" label="32031" help="">
-			<group id="1">
-				<setting id="enable-africaandthemiddleeast" type="boolean" label="32081" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-africanight" type="boolean" label="32082" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-alaskanjellies" type="boolean" label="32083" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-antarctica" type="boolean" label="32084" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-atlanticoceantospainandfrance" type="boolean" label="32085" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-australia" type="boolean" label="32086" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-barracuda" type="boolean" label="32087" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-bumpheads" type="boolean" label="32088" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-californiadolphins" type="boolean" label="32089" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-californiakelpforest" type="boolean" label="32090" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-californiatovegas" type="boolean" label="32091" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-caribbeanday" type="boolean" label="32092" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-caribbean" type="boolean" label="32093" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-china" type="boolean" label="32094" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-costaricadolphins" type="boolean" label="32095" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-cownoserays" type="boolean" label="32096" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-dubai" type="boolean" label="32097" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-grandcanyon" type="boolean" label="32098" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-grayreefsharks" type="boolean" label="32099" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-greenland" type="boolean" label="32100" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-hawaii" type="boolean" label="32101" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-hongkong" type="boolean" label="32102" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-humpbackwhale" type="boolean" label="32103" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-iceland" type="boolean" label="32104" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-iranandafghanistan" type="boolean" label="32105" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-irelandtoasia" type="boolean" label="32106" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-italytoasia" type="boolean" label="32107" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-jacks" type="boolean" label="32108" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-kelp" type="boolean" label="32109" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-koreaandjapannight" type="boolean" label="32110" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-liwa" type="boolean" label="32111" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-london" type="boolean" label="32112" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-losangeles" type="boolean" label="32113" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-newyorknight" type="boolean" label="32114" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-newyork" type="boolean" label="32115" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-newzealand" type="boolean" label="32116" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-niledelta" type="boolean" label="32117" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-northamericaaurora" type="boolean" label="32118" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-palaucoral" type="boolean" label="32119" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-palaujellies" type="boolean" label="32120" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-patagonia" type="boolean" label="32121" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-redseacoral" type="boolean" label="32122" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-saharaanditaly" type="boolean" label="32123" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-sanfrancisco" type="boolean" label="32124" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-scotland" type="boolean" label="32125" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-seastars" type="boolean" label="32126" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-seals" type="boolean" label="32127" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-southafricatonorthasia" type="boolean" label="32128" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-southerncaliforniatobaja" type="boolean" label="32129" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-tahitiwaves" type="boolean" label="32130" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-westafricatothealps" type="boolean" label="32131" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="enable-yosemite" type="boolean" label="32132" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-			</group>
-		</category>
-		<category id="offline mode" label="32009" help="">
-			<group id="1">
-				<setting id="download-folder" type="path" label="32010" help="">
-					<level>0</level>
-					<default/>
-					<constraints>
-						<writable>false</writable>
-						<allowempty>true</allowempty>
-					</constraints>
-					<control type="button" format="path">
-						<heading>32010</heading>
-					</control>
-				</setting>
-				<setting id="force-offline" type="boolean" label="32043" help="32080">
-					<level>0</level>
-					<default>false</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="get-videos-from-apple" type="boolean" label="32078" help="32079">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-					<dependencies>
-						<dependency type="visible">
-							<or>
-								<condition operator="is" setting="force-offline">false</condition>
-							</or>
-						</dependency>
-					</dependencies>
-				</setting>
-				<setting id="enable-checksums" type="boolean" label="32030" help="">
-					<level>0</level>
-					<default>true</default>
-					<control type="toggle"/>
-				</setting>
-				<setting id="run-downloader" type="action" label="32011" help="">
-					<level>0</level>
-					<data>RunAddon(screensaver.atv4,offline)</data>
-					<constraints>
-						<allowempty>true</allowempty>
-					</constraints>
-					<control type="button" format="action"/>
-				</setting>
-			</group>
-		</category>
-	</section>
+    <section id="screensaver.atv4">
+        <category id="aerial screensavers" label="32000" help="">
+            <group id="1" label="32032">
+                <setting id="show-notifications" type="boolean" label="32018" help="">
+                    <level>0</level>
+                    <default>false</default>
+                    <control type="toggle" />
+                </setting>
+                <setting id="show-previewwindow" type="boolean" label="32042" help="">
+                    <level>0</level>
+                    <default>false</default>
+                    <control type="toggle" />
+                </setting>
+                <setting id="enable-4k" type="boolean" label="32075" help="">
+                    <level>0</level>
+                    <default>false</default>
+                    <control type="toggle" />
+                </setting>
+                <setting id="enable-hdr" type="boolean" label="32076" help="">
+                    <level>0</level>
+                    <default>false</default>
+                    <control type="toggle" />
+                </setting>
+                <setting id="enable-hevc" type="boolean" label="32077" help="">
+                    <level>0</level>
+                    <default>false</default>
+                    <control type="toggle" />
+                </setting>
+            </group>
+            <group id="2" label="32026">
+                <setting id="check-dpms" type="integer" label="32027" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="32035">0</option>
+                            <option label="32036">1</option>
+                            <option label="32037">2</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="dpms-action" type="integer" label="32039" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="32040">0</option>
+                            <option label="32041">1</option>
+                        </options>
+                    </constraints>
+                    <dependencies>
+                        <dependency type="visible">
+                            <or>
+                                <condition operator="is" setting="check-dpms">1</condition>
+                                <condition operator="is" setting="check-dpms">2</condition>
+                            </or>
+                        </dependency>
+                    </dependencies>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="manual-dpms" type="integer" label="32038" help="">
+                    <level>0</level>
+                    <default>5</default>
+                    <constraints>
+                        <minimum>1</minimum>
+                        <step>5</step>
+                        <maximum>120</maximum>
+                    </constraints>
+                    <dependencies>
+                        <dependency type="visible">
+                            <condition operator="is" setting="check-dpms">2</condition>
+                        </dependency>
+                    </dependencies>
+                    <control type="slider" format="integer">
+                        <popup>false</popup>
+                    </control>
+                </setting>
+                <setting id="toggle-displayoff" type="boolean" label="32028" help="">
+                    <level>0</level>
+                    <default>false</default>
+                    <dependencies>
+                        <dependency type="visible">
+                            <or>
+                                <condition operator="is" setting="check-dpms">1</condition>
+                                <condition operator="is" setting="check-dpms">2</condition>
+                            </or>
+                        </dependency>
+                    </dependencies>
+                    <control type="toggle" />
+                </setting>
+                <setting id="toggle-cecoff" type="boolean" label="32029" help="">
+                    <level>0</level>
+                    <default>false</default>
+                    <dependencies>
+                        <dependency type="visible">
+                            <or>
+                                <condition operator="is" setting="check-dpms">1</condition>
+                                <condition operator="is" setting="check-dpms">2</condition>
+                            </or>
+                        </dependency>
+                    </dependencies>
+                    <control type="toggle" />
+                </setting>
+            </group>
+            <group id="3" label="32033" />
+            <group id="4" label="32034">
+                <setting id="is_locked" type="boolean" help="">
+                    <level>0</level>
+                    <default>false</default>
+                    <dependencies>
+                        <dependency type="visible">
+                            <condition on="property" name="InfoBool">false</condition>
+                        </dependency>
+                    </dependencies>
+                    <control type="toggle" />
+                </setting>
+            </group>
+        </category>
+        <category id="videos" label="32031" help="">
+            <group id="1">
+                <setting id="enable-africaandthemiddleeast" type="integer" label="32081" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-africanight" type="integer" label="32082" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-alaskanjellies" type="integer" label="32083" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-antarctica" type="integer" label="32084" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-atlanticoceantospainandfrance" type="integer" label="32085" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-australia" type="integer" label="32086" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-barracuda" type="integer" label="32087" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-bumpheads" type="integer" label="32088" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-californiadolphins" type="integer" label="32089" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-californiakelpforest" type="integer" label="32090" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-californiatovegas" type="integer" label="32091" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-caribbeanday" type="integer" label="32092" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-caribbean" type="integer" label="32093" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-china" type="integer" label="32094" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-costaricadolphins" type="integer" label="32095" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-cownoserays" type="integer" label="32096" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-dubai" type="integer" label="32097" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-grandcanyon" type="integer" label="32098" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-grayreefsharks" type="integer" label="32099" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-greenland" type="integer" label="32100" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-hawaii" type="integer" label="32101" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-hongkong" type="integer" label="32102" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-humpbackwhale" type="integer" label="32103" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-iceland" type="integer" label="32104" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-iranandafghanistan" type="integer" label="32105" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-irelandtoasia" type="integer" label="32106" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-italytoasia" type="integer" label="32107" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-jacks" type="integer" label="32108" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-kelp" type="integer" label="32109" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-koreaandjapannight" type="integer" label="32110" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-liwa" type="integer" label="32111" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-london" type="integer" label="32112" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-losangeles" type="integer" label="32113" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-newyorknight" type="integer" label="32114" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-newyork" type="integer" label="32115" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-newzealand" type="integer" label="32116" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-niledelta" type="integer" label="32117" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-northamericaaurora" type="integer" label="32118" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-palaucoral" type="integer" label="32119" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-palaujellies" type="integer" label="32120" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-patagonia" type="integer" label="32121" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-redseacoral" type="integer" label="32122" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-saharaanditaly" type="integer" label="32123" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-sanfrancisco" type="integer" label="32124" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-scotland" type="integer" label="32125" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-seastars" type="integer" label="32126" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-seals" type="integer" label="32127" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-southafricatonorthasia" type="integer" label="32128" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-southerncaliforniatobaja" type="integer" label="32129" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-tahitiwaves" type="integer" label="32130" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-westafricatothealps" type="integer" label="32131" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+                <setting id="enable-yosemite" type="integer" label="32132" help="">
+                    <level>0</level>
+                    <default>0</default>
+                    <constraints>
+                        <options>
+                            <option label="34001">0</option>
+                            <option label="34002">1</option>
+                            <option label="34003">2</option>
+                            <option label="34004">3</option>
+                        </options>
+                    </constraints>
+                    <control type="spinner" format="string" />
+                </setting>
+            </group>
+        </category>
+        <category id="offline mode" label="32009" help="">
+            <group id="1">
+                <setting id="download-folder" type="path" label="32010" help="">
+                    <level>0</level>
+                    <default />
+                    <constraints>
+                        <writable>false</writable>
+                        <allowempty>true</allowempty>
+                    </constraints>
+                    <control type="button" format="path">
+                        <heading>32010</heading>
+                    </control>
+                </setting>
+                <setting id="force-offline" type="boolean" label="32043" help="32080">
+                    <level>0</level>
+                    <default>false</default>
+                    <control type="toggle" />
+                </setting>
+                <setting id="get-videos-from-apple" type="boolean" label="32078" help="32079">
+                    <level>0</level>
+                    <default>true</default>
+                    <control type="toggle" />
+                    <dependencies>
+                        <dependency type="visible">
+                            <or>
+                                <condition operator="is" setting="force-offline">false</condition>
+                            </or>
+                        </dependency>
+                    </dependencies>
+                </setting>
+                <setting id="enable-checksums" type="boolean" label="32030" help="">
+                    <level>0</level>
+                    <default>true</default>
+                    <control type="toggle" />
+                </setting>
+                <setting id="run-downloader" type="action" label="32011" help="">
+                    <level>0</level>
+                    <data>RunAddon(screensaver.atv4,offline)</data>
+                    <constraints>
+                        <allowempty>true</allowempty>
+                    </constraints>
+                    <control type="button" format="action" />
+                </setting>
+            </group>
+        </category>
+    </section>
 </settings>


### PR DESCRIPTION
This PR allows videos to be enabled/disabled based on time of day. This may be desired to avoid showing videos with bright blue or white light at night (e.g. underwater scenes), or to have day/night scenes play at corresponding day/night time. The following changes were made:

- converted video settings (in `settings.xml`) from boolean (enabled/disabled) to integer with the following options:
  - 0: On
  - 1: Day Only
  - 2: Night Only
  - 3: Off
-  The corresponding labels for these new options have also been added to the language `strings.po` files.
- These settings are compared with the system time as parsed out in `resources/lib/playlist.py` to determine whether to play a video when the screensaver is invoked.
